### PR TITLE
Add honest-numbers framing banner to /eval

### DIFF
--- a/apps/frontend/src/app/eval/eval-public-view.tsx
+++ b/apps/frontend/src/app/eval/eval-public-view.tsx
@@ -41,6 +41,29 @@ export function EvalPublicView() {
   const hasPromoted = promotedSuites.length > 0;
   return (
     <div className="container mx-auto max-w-5xl px-6 py-14">
+      {/* Honest-numbers framing banner (F08) — additive, no logic change. */}
+      <section
+        className="surface mb-10 p-6"
+        aria-label="How to read these numbers"
+        data-testid="eval-honest-numbers-banner"
+      >
+        <div className="mb-2 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+          <ShieldCheck className="h-3 w-3 text-primary" aria-hidden />
+          <span>How to read these numbers</span>
+        </div>
+        <p className="max-w-3xl font-body text-sm text-muted-foreground">
+          Three golden suites, judged honestly and published whole — strong and
+          weak alike. Authoring scores 3.85/5 (n=10). Tutor (2.33/5) and ingest
+          (0.83/5) are early, with documented causes: the tutor&apos;s low
+          citation score is a mismatch between the eval&apos;s expected citations
+          and what the retriever pulls (relevant chunks land, just not the
+          hardcoded ones), and ingest scored only the items that fully ingested
+          while the v1 chunker emits one module per video. The point of
+          publishing the weak numbers is that every score is measured,
+          reproducible, and gated by a CI smoke on every PR.
+        </p>
+      </section>
+
       {/* Hero */}
       <header className="mb-12 flex flex-col gap-3">
         <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
Adds a short framing banner so the real, published eval numbers read as rigor, not failure. Additive only — no logic changes. Part of the personal-brand polish (F08).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational banner to the evaluation results page that helps users understand how to interpret evaluation metrics. The banner includes explanatory text and visual elements, positioned prominently at the top of the page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahmedEid1/lumen/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->